### PR TITLE
Create admin-browser-support.md

### DIFF
--- a/docs/ViaFoundry/admin-browser-support.md
+++ b/docs/ViaFoundry/admin-browser-support.md
@@ -4,10 +4,10 @@ Last Updated: December 1, 2023
 ### Via Foundry officially supports the following browsers on Windows and macOS desktop:
 - Google Chrome (current version)
 - Firefox (current version)
-- Safari (current version)
 - Microsoft Edge (current version). You might see performance degradation for some features on Microsoft Edge.
 
-### The following browsers are not supported:
+### The following browsers are not officially supported:
+- Safari
 - Internet Explorer
 - Mobile browsers
 - Beta, "preview", or other pre-release versions of desktop browsers

--- a/docs/ViaFoundry/admin-browser-support.md
+++ b/docs/ViaFoundry/admin-browser-support.md
@@ -1,0 +1,15 @@
+## Via Foundry Supported browsers
+Last Updated: December 1, 2023
+
+### Via Foundry officially supports the following browsers on Windows and macOS desktop:
+- Google Chrome (current version)
+- Firefox (current version)
+- Safari (current version)
+- Microsoft Edge (current version). You might see performance degradation for some features on Microsoft Edge.
+
+### The following browsers are not supported:
+- Internet Explorer
+- Mobile browsers
+- Beta, "preview", or other pre-release versions of desktop browsers
+
+Using an unsupported browser might cause unexpected behavior, including security issues. Via Foundry can assist only in those support cases where an officially supported browser is being used.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,5 +46,6 @@
 - [Installation](ViaFoundry/admin-installation.md)
 - [Configuration](ViaFoundry/admin-configuration.md)
 - [Testing Pipeline](ViaFoundry/admin-pipeline-testing.md)
-- [APP Section](ViaFoundry/admin-installation-apps.md)
+- [App Section](ViaFoundry/admin-installation-apps.md)
+- [Browser Support](ViaFoundry/admin-browser-support.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,5 +58,6 @@ nav:
       - "Installation": ViaFoundry/admin-installation.md
       - "Configuration": ViaFoundry/admin-configuration.md
       - "Testing Pipeline": ViaFoundry/admin-pipeline-testing.md
-      - "APP Section": ViaFoundry/admin-installation-apps.md
+      - "App Section": ViaFoundry/admin-installation-apps.md
+      - "Browser Support": ViaFoundry/admin-browser-support.md
 


### PR DESCRIPTION
Add a list of browsers that we'll claim we "officially support". This doesn't mean we won't help customers who use unsupported browsers however we can, but it does protect us against people using 5 year old browsers and reporting support issues.